### PR TITLE
Fix end-of-line rendering

### DIFF
--- a/src/sixel.h
+++ b/src/sixel.h
@@ -84,8 +84,8 @@ namespace MR {
           for (int y = 0; y < y_dim; y += 6)
             out += encode (y);
 
-          out += "\033\\\n";
-          std::cout << out;
+          out += "\033\\";
+          std::cout << out << std::endl;
         }
 
       private:

--- a/src/sixel.h
+++ b/src/sixel.h
@@ -84,7 +84,7 @@ namespace MR {
           for (int y = 0; y < y_dim; y += 6)
             out += encode (y);
 
-          out += "\033\\";
+          out += "\033\\\n";
           std::cout << out;
         }
 


### PR DESCRIPTION
Adds a line break at the end of the output to fix rendering on iTerm2.

Current master:
<img width="794" alt="Screenshot 2020-06-17 at 16 04 54" src="https://user-images.githubusercontent.com/7466983/84915462-bc6bba80-b0b4-11ea-9646-61f288fd6e90.png">

Proposed PR:
<img width="795" alt="Screenshot 2020-06-17 at 16 05 55" src="https://user-images.githubusercontent.com/7466983/84915483-c392c880-b0b4-11ea-819b-dca07623076c.png">

