### PR TITLE
mrpeek: x switches arrow keys to interactive focus

### DIFF
--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -272,8 +272,8 @@ void show_help ()
   VT::position_cursor_at (row++, 4); std::cout << "left/right            previous/next volume";
   VT::position_cursor_at (row++, 4); std::cout << "a / s / c             axial / sagittal / coronal projection";
   VT::position_cursor_at (row++, 4); std::cout << "- / +                 zoom out / in";
-  VT::position_cursor_at (row++, 4); std::cout << "x                     toggle arrow key control of slice/volume and crosshairs";
-  VT::position_cursor_at (row++, 4); std::cout << "b                     toggle arrow key brighness control";
+  VT::position_cursor_at (row++, 4); std::cout << "x / <space>           toggle arrow key crosshairs control";
+  VT::position_cursor_at (row++, 4); std::cout << "b                     toggle arrow key brightness control";
   VT::position_cursor_at (row++, 4); std::cout << "f                     show / hide crosshairs";
   VT::position_cursor_at (row++, 4); std::cout << "r                     reset focus";
   VT::position_cursor_at (row++, 4); std::cout << "left mouse & drag     move focus";
@@ -418,6 +418,7 @@ void run ()
                   focus[slice_axis] = std::round (image.size(slice_axis)/2); std::cout << VT::ClearScreen; break;
         case '+': scale_image *= 1.1; std::cout << VT::ClearScreen; break;
         case '-': scale_image /= 1.1; std::cout << VT::ClearScreen; break;
+        case ' ':
         case 'x': arrow_mode = x_arrow_mode = (x_arrow_mode == ARROW_SLICEVOL) ? ARROW_CROSSHAIR : ARROW_SLICEVOL; break;
         case 'b': arrow_mode = (arrow_mode == ARROW_COLOUR) ? x_arrow_mode : ARROW_COLOUR; std::cout << VT::ClearScreen; break;
         case VT::MouseMoveLeft: focus[x_axis] += xp-x; focus[y_axis] += yp-y; break;

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -221,24 +221,21 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
   image.index(0) = focus[0];
   image.index(1) = focus[1];
   image.index(2) = focus[2];
-  std::cout << VT::CarriageReturn << VT::ClearLine << "[ "; //<< focus[0] << " " << focus[1] << " " << focus[2] << " ";
+  std::cout << VT::CarriageReturn << VT::ClearLine << "[ ";
   for (int d = 0; d < 3; d++) {
     if (d == x_axis || d == y_axis) {
-      if (modify_focus) std::cout << VT::TextUnderscore;
-      std::cout << VT::TextReverseColour;
-    } else if (!modify_focus) std::cout << VT::TextUnderscore;
+        if (modify_focus) std::cout << VT::TextForegroundYellow;
+        std::cout << VT::TextUnderscore;
+    }
     std::cout << focus[d];
     std::cout << VT::TextReset;
     std::cout << " ";
   }
   for (size_t n = 3; n < image.ndim(); ++n) {
-    if (n == 3 && !modify_focus)
-      std::cout << VT::TextUnderscore;
     std::cout << image.index(n);
-    std::cout << VT::TextReset;
     std::cout << " ";
   }
-  std::cout << "]: " << image.value();
+  std::cout << "]: " << image.value() << VT::TextReset;
 
   std::cout.flush();
 }

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -134,9 +134,9 @@ int colourmap_ID = 0;
 int levels = 64;
 int x_axis, y_axis, slice_axis = 2;
 value_type pmin = DEFAULT_PMIN, pmax = DEFAULT_PMAX, scale_image = 1.0;
-bool crosshair = true, colorbar = false;
+bool crosshair = true, colorbar = true;
 vector<int> focus (3, 0);  // relative to original image grid
-ArrowMode arrow_mode = ARROW_SLICEVOL;
+ArrowMode x_arrow_mode = ARROW_SLICEVOL, arrow_mode = x_arrow_mode;
 
 
 inline void set_axes ()
@@ -272,8 +272,8 @@ void show_help ()
   VT::position_cursor_at (row++, 4); std::cout << "left/right            previous/next volume";
   VT::position_cursor_at (row++, 4); std::cout << "a / s / c             axial / sagittal / coronal projection";
   VT::position_cursor_at (row++, 4); std::cout << "- / +                 zoom out / in";
-  VT::position_cursor_at (row++, 4); std::cout << "x                     select what arrow keys act on from ";
-  VT::position_cursor_at (row++, 4); std::cout << "                        slice/volume, crosshairs, or colour";
+  VT::position_cursor_at (row++, 4); std::cout << "x                     toggle arrow key control of slice/volume and crosshairs";
+  VT::position_cursor_at (row++, 4); std::cout << "b                     toggle arrow key brighness control";
   VT::position_cursor_at (row++, 4); std::cout << "f                     show / hide crosshairs";
   VT::position_cursor_at (row++, 4); std::cout << "r                     reset focus";
   VT::position_cursor_at (row++, 4); std::cout << "left mouse & drag     move focus";
@@ -418,8 +418,8 @@ void run ()
                   focus[slice_axis] = std::round (image.size(slice_axis)/2); std::cout << VT::ClearScreen; break;
         case '+': scale_image *= 1.1; std::cout << VT::ClearScreen; break;
         case '-': scale_image /= 1.1; std::cout << VT::ClearScreen; break;
-        case 'x': arrow_mode = static_cast<ArrowMode>((arrow_mode + 1) % N_ARROW_MODES); break;
-        case 'b': colorbar = !colorbar; std::cout << VT::ClearScreen; break;
+        case 'x': arrow_mode = x_arrow_mode = (x_arrow_mode == ARROW_SLICEVOL) ? ARROW_CROSSHAIR : ARROW_SLICEVOL; break;
+        case 'b': arrow_mode = (arrow_mode == ARROW_COLOUR) ? x_arrow_mode : ARROW_COLOUR; std::cout << VT::ClearScreen; break;
         case VT::MouseMoveLeft: focus[x_axis] += xp-x; focus[y_axis] += yp-y; break;
         case VT::Escape: colourmap.invalidate_scaling(); break;
         case VT::MouseMoveRight: colourmap.update_scaling (x-xp, y-yp); break;

--- a/src/vt_control.h
+++ b/src/vt_control.h
@@ -17,6 +17,10 @@ namespace MR {
     constexpr const char* CursorOff = "\033[?25l";
     constexpr const char* CursorOn = "\033[?25h";
 
+    constexpr const char* TextReverseColour = "\033[7m";
+    constexpr const char* TextUnderscore = "\033[4m";
+    constexpr const char* TextReset = "\033[0m";
+
     constexpr const char* MouseTrackingOn = "\033[?1002h";
     constexpr const char* MouseTrackingOff = "\033[?1002l";
 

--- a/src/vt_control.h
+++ b/src/vt_control.h
@@ -17,8 +17,8 @@ namespace MR {
     constexpr const char* CursorOff = "\033[?25l";
     constexpr const char* CursorOn = "\033[?25h";
 
-    constexpr const char* TextReverseColour = "\033[7m";
     constexpr const char* TextUnderscore = "\033[4m";
+    constexpr const char* TextForegroundYellow = "\033[33m";
     constexpr const char* TextReset = "\033[0m";
 
     constexpr const char* MouseTrackingOn = "\033[?1002h";


### PR DESCRIPTION
x toggles arrow keys between inplane coordinates and slice/volumes

in 9eaf851, I tried to show the state:
- the active plane dimensions are highlighted by reversing the colour
- dimensions modified with arrow keys are underscored

![image](https://user-images.githubusercontent.com/10046944/85126606-1cd23780-b22e-11ea-956f-1ff745d92b0f.png)

but I guess d183578e6909bbdd73c022286a4515ee62121f82 is a better solution?
- the active plane dimensions are highlighted by underscore
- dimensions modified with arrow keys written in yellow (no background)

![image](https://user-images.githubusercontent.com/10046944/85128196-1d200200-b231-11ea-858c-c32b62180958.png) ![image](https://user-images.githubusercontent.com/10046944/85128352-5e181680-b231-11ea-85b7-f4afa0447485.png)



