### PR TITLE
mrpeek: minor optimisation for sixel encoding

### DIFF
--- a/src/sixel.h
+++ b/src/sixel.h
@@ -113,22 +113,13 @@ namespace MR {
 
         std::string encode (int y0) {
           std::string out;
-          bool is_background = true;
 
           for (int intensity = 0; intensity <= colourmap.maximum(); ++intensity) {
             for (int i = y0*x_dim; i < (y0+6)*x_dim; ++i) {
               // if any voxel in buffer has this intensity, then need to encode the
               // whole row of sixels:
               if (data[i] == intensity) {
-                if (is_background) {
-                  is_background = false;
-                  current = '?';
-                  repeats = x_dim;
-                  commit();
-                  out += "#" + str(intensity) + buffer + '$';
-                }
-                else
-                  out += encode (y0, intensity);
+                out += encode (y0, intensity);
                 break;
               }
             }


### PR DESCRIPTION
Based on recent discussion with Guillaume Flandin on OHBM Mattermost channel, and [this site](https://qiita.com/arakiken/items/4a216af6547d2574d283) he alerted me to. 

Seems our encoding is about as efficient as it could be. These modifications reduce the frame size for a 256×244 grayscale image from 72kb to 65kb. Not enormously exciting, but as it was simple to implement...