### PR TITLE
Add support for NaN values

### DIFF
--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -193,10 +193,8 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
 
     std::vector<value_type> currentslice (x_dim*y_dim);
     size_t k = 0;
-    for (auto l = Loop ({ size_t(x_axis), size_t(y_axis) })(image_regrid); l; ++l) {
-      value_type pix = image_regrid.value();
-      currentslice[k++] = std::isnan(pix) ? 0 : pix;
-    }
+    for (auto l = Loop ({ size_t(x_axis), size_t(y_axis) })(image_regrid); l; ++l)
+      currentslice[k++] = image_regrid.value();
 
     value_type vmin = percentile(currentslice, pmin);
     value_type vmax = percentile(currentslice, pmax);
@@ -210,8 +208,7 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
     image_regrid.index(y_axis) = y_dim-1-y;
     for (int x = 0; x < x_dim; ++x) {
       image_regrid.index(x_axis) = x_dim-1-x;
-      value_type pix = image_regrid.value();
-      encoder(x, y, std::isnan(pix) ? 0 : pix);
+      encoder(x, y, image_regrid.value());
     }
   }
 

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -241,7 +241,7 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
     }
     std::cout << std::endl << VT::CarriageReturn << VT::ClearLine;
     colorbar_encoder.write();
-    std::cout << " [ " << -colourmap.offset() << " " << 1.0 / colourmap.scale() - colourmap.offset() <<  " ] " << std::endl;
+    std::cout << " [ " << colourmap.min() << " " << colourmap.max() <<  " ] " << std::endl;
   }
 
   image.index(0) = focus[0];

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -110,10 +110,8 @@ template <class Container>
 value_type percentile (Container& data, default_type percentile)
 {
   // ignore nan
-  data.erase (std::remove_if (data.begin(), data.end(),
-              [](typename Container::value_type val) {
-                return !std::isfinite(val);
-              }), data.end());
+  auto isnotfinite = [](typename Container::value_type val) { return !std::isfinite(val); };
+  data.erase (std::remove_if (data.begin(), data.end(), isnotfinite), data.end());
   if (percentile == 100.0) {
     return default_type(*std::max_element (data.begin(), data.end()));
   } else if (percentile == 0.0) {

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -75,7 +75,7 @@ void usage ()
   + Option ("percentile_range",
             "specify intensity range of the data. The image intensity will be scaled "
             "between the specified minimum and maximum percentile values. "
-            "Defaults are: " + str(DEFAULT_PMIN) + " - " + str(DEFAULT_PMAX))
+            "Defaults are: " + str(DEFAULT_PMIN, 3) + " - " + str(DEFAULT_PMAX, 3))
   +   Argument ("min").type_float()
   +   Argument ("max").type_float()
 

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -109,6 +109,8 @@ using value_type = float;
 template <class Container>
 value_type percentile (Container& data, default_type percentile)
 {
+  // replace NaN with 0
+  std::replace_if (data.begin(), data.end(), std::isnan<typename Container::value_type>, 0);
   if (percentile == 100.0) {
     return default_type(*std::max_element (data.begin(), data.end()));
   } else if (percentile == 0.0) {

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -193,8 +193,10 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
 
     std::vector<value_type> currentslice (x_dim*y_dim);
     size_t k = 0;
-    for (auto l = Loop ({ size_t(x_axis), size_t(y_axis) })(image_regrid); l; ++l)
-      currentslice[k++] = image_regrid.value();
+    for (auto l = Loop ({ size_t(x_axis), size_t(y_axis) })(image_regrid); l; ++l) {
+      value_type pix = image_regrid.value();
+      currentslice[k++] = std::isnan(pix) ? 0 : pix;
+    }
 
     value_type vmin = percentile(currentslice, pmin);
     value_type vmax = percentile(currentslice, pmax);
@@ -208,7 +210,8 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
     image_regrid.index(y_axis) = y_dim-1-y;
     for (int x = 0; x < x_dim; ++x) {
       image_regrid.index(x_axis) = x_dim-1-x;
-      encoder(x, y, image_regrid.value());
+      value_type pix = image_regrid.value();
+      encoder(x, y, std::isnan(pix) ? 0 : pix);
     }
   }
 

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -109,8 +109,9 @@ using value_type = float;
 template <class Container>
 value_type percentile (Container& data, default_type percentile)
 {
-  // replace NaN with 0
-  std::replace_if (data.begin(), data.end(), std::isnan<typename Container::value_type>, 0);
+  // ignore nan
+  data.erase (std::remove_if (data.begin(), data.end(),
+              std::isnan<typename Container::value_type>), data.end());
   if (percentile == 100.0) {
     return default_type(*std::max_element (data.begin(), data.end()));
   } else if (percentile == 0.0) {

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -111,7 +111,9 @@ value_type percentile (Container& data, default_type percentile)
 {
   // ignore nan
   data.erase (std::remove_if (data.begin(), data.end(),
-              std::isnan<typename Container::value_type>), data.end());
+              [](typename Container::value_type val) {
+                return !std::isfinite(val);
+              }), data.end());
   if (percentile == 100.0) {
     return default_type(*std::max_element (data.begin(), data.end()));
   } else if (percentile == 0.0) {

--- a/src/sixel.h
+++ b/src/sixel.h
@@ -8,7 +8,7 @@
 namespace MR {
   namespace Sixel {
 
-    constexpr float BrightnessIncrement = 0.03;
+    constexpr float BrightnessIncrement = 10.0f;
     constexpr float ContrastIncrement = 0.03;
 
     class ColourMap {
@@ -45,15 +45,15 @@ namespace MR {
         // set offset * scale parameters to adjust brightness / contrast:
         bool scaling_set () const { return std::isfinite (_offset) && std::isfinite (_scale); }
         void invalidate_scaling () { _offset = _scale = NaN; }
-        void set_scaling (float offset, float scale) { _offset = offset; _scale = scale*num_colours; }
+        void set_scaling (float offset, float scale) { _offset = offset*num_colours; _scale = scale*num_colours; }
         void set_scaling_min_max (float vmin, float vmax) { float dv = vmax - vmin; set_scaling (-vmin/dv, 1.0f/dv ); }
         void update_scaling (int x, int y) {
           float mid = _offset + 0.5f*_scale;
-          mid += BrightnessIncrement * y / _scale;
-          _scale = std::exp (std::log(_scale) + ContrastIncrement * x);
+          mid += BrightnessIncrement * x * _scale;
+          _scale = std::exp (std::log(_scale) - ContrastIncrement * y);
           _offset = mid - 0.5f*_scale;
         }
-        const float offset () const { return _offset; }
+        const float offset () const { return _offset/num_colours; }
         const float scale () const { return _scale/num_colours; }
         const float min () const { return -offset() / scale(); }
         const float max () const { return (1.f - offset()) / scale(); }

--- a/src/sixel.h
+++ b/src/sixel.h
@@ -46,7 +46,7 @@ namespace MR {
         bool scaling_set () const { return std::isfinite (_offset) && std::isfinite (_scale); }
         void invalidate_scaling () { _offset = _scale = NaN; }
         void set_scaling (float offset, float scale) { _offset = offset; _scale = scale*num_colours; }
-        void set_scaling_min_max (float vmin, float vmax) { set_scaling (-vmin, 1.0f / (vmax - vmin)); }
+        void set_scaling_min_max (float vmin, float vmax) { float dv = vmax - vmin; set_scaling (-vmin/dv, 1.0f/dv ); }
         void update_scaling (int x, int y) {
           float mid = _offset + 0.5f*_scale;
           mid += BrightnessIncrement * y / _scale;
@@ -55,6 +55,8 @@ namespace MR {
         }
         const float offset () const { return _offset; }
         const float scale () const { return _scale/num_colours; }
+        const float min () const { return -offset() / scale(); }
+        const float max () const { return (1.f - offset()) / scale(); }
 
       private:
         int num_colours;


### PR DESCRIPTION
Implements a quick fix by replacing all NaN values with zero. The voxel intensity value is printed as `nan`.