### PR TITLE
Orthoview support

### DIFF
--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -232,6 +232,10 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
       auto image_regrid1 = Adapter::make<Reslicer> (image, regrid_header(image, scale));
       x_dim = image_regrid1.size(x_axis);
       y_dim = image_regrid1.size(y_axis);
+      // recentring
+      int dx = (panel_x_dim - x_dim) / 2;
+      int dy = (panel_y_dim - y_dim) / 2;
+
       encoder.set_panel(slice_axis);
 
       image_regrid1.index(slice_axis) = focus[slice_axis];
@@ -239,7 +243,7 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
         image_regrid1.index(y_axis) = y_dim-1-y;
         for (int x = 0; x < x_dim; ++x) {
           image_regrid1.index(x_axis) = x_dim-1-x;
-          encoder(x, y, image_regrid1.value());
+          encoder(x+dx, y+dy, image_regrid1.value());
         }
       }
     
@@ -248,7 +252,7 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
         int y = std::round(y_dim - image.spacing(y_axis) * (focus[y_axis] + 0.5) / scale);
         x = std::max (std::min (x, x_dim-1), 0);
         y = std::max (std::min (y, y_dim-1), 0);
-        encoder.draw_crosshairs (x,y);
+        encoder.draw_crosshairs (x+dx, y+dy);
       }
     }
     slice_axis = backup_slice_axis;

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -202,7 +202,7 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
     INFO("reset intensity range to " + str(vmin) + " - " +str(vmax));
   }
 
-  Sixel::Encoder encoder (x_dim, y_dim, colourmap);
+  Sixel::Encoder<> encoder (x_dim, y_dim, colourmap);
 
   for (int y = 0; y < y_dim; ++y) {
     image_regrid.index(y_axis) = y_dim-1-y;
@@ -227,7 +227,7 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
   if (colorbar) {
     int cbar_x_dim = std::max(40, (int) std::round(x_dim * 0.2));
     int cbar_y_dim = std::max(10, (int) std::round(1.f * scale_image));
-    Sixel::Encoder colorbar_encoder (cbar_x_dim, cbar_y_dim, colourmap);
+    Sixel::Encoder<> colorbar_encoder (cbar_x_dim, cbar_y_dim, colourmap);
     for (int x = 0; x < cbar_x_dim; ++x) {
       value_type val = (value_type) x / std::max(1, cbar_x_dim - 1) / colourmap.scale();
       for (int y = 0; y < cbar_y_dim; ++y) {

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -254,6 +254,7 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
         y = std::max (std::min (y, y_dim-1), 0);
         encoder.draw_crosshairs (x+dx, y+dy);
       }
+      encoder.draw_boundingbox (slice_axis == backup_slice_axis);
     }
     slice_axis = backup_slice_axis;
 
@@ -278,6 +279,8 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
       y = std::max (std::min (y, y_dim-1), 0);
       encoder.draw_crosshairs (x,y);
     }
+
+    encoder.draw_boundingbox (true);
 
     // encode buffer and print out:
     encoder.write();

--- a/src/sixel.h
+++ b/src/sixel.h
@@ -26,13 +26,16 @@ namespace MR {
                 str(std::round(colour[1]))+";"+
                 str(std::round(colour[2]));
             }
-            specifier += "#"+str(num_colours+1)+";2;100;100;0$\n";
+            specifier += "#"+str(num_colours+1)+";2;100;100;0";    // crosshair
+            specifier += "#"+str(num_colours+2)+";2;30;30;30";     // boundingbox
+            specifier += "#"+str(num_colours+3)+";2;55;55;40$\n";  // boundingbox highlight
           }
 
         const std::string& spec () const { return specifier; }
-        const int maximum () const { return num_colours+1; }
+        const int maximum () const { return num_colours+3; }
         const int range () const { return num_colours; }
         const int crosshairs() const { return num_colours+1; }
+        const int boundingbox(bool highlight = false) const { return num_colours+2+int(highlight); }
 
 
         // apply rescaling from floating-point value to clamped rescaled
@@ -101,6 +104,18 @@ namespace MR {
             data[mapxy(x0,y)] = colourmap.crosshairs();
         }
 
+        // add yellow crosshairs at the specified position:
+        void draw_boundingbox (bool highlight = false) {
+          for (int x = 0; x < x_dim; ++x) {
+            data[mapxy(x,0)] = colourmap.boundingbox(highlight);
+            data[mapxy(x,y_dim-1)] = colourmap.boundingbox(highlight);
+          }
+          for (int y = 0; y < y_dim; ++y) {
+            data[mapxy(0,y)] = colourmap.boundingbox(highlight);
+            data[mapxy(x_dim-1,y)] = colourmap.boundingbox(highlight);
+          }
+        }
+
         // once slice is fully specified, encode and write to stdout:
         void write () {
           std::string out = VT::SixelStart + colourmap.spec();
@@ -123,6 +138,8 @@ namespace MR {
         int repeats;
 
         inline size_t mapxy (int x, int y) const {
+          assert (x < x_dim);
+          assert (y < y_dim);
           return x + x_dim*(gi + gx*(y + y_dim*gj));
         }
 


### PR DESCRIPTION
This PR adds support for showing three orthogonal slices in horizontal lay-out, as suggested in #17. Orthoview is toggled with `o`; `s / c / a` continue to select the "active" plane to control the focus. The slice and crosshairs are updated in all planes.

<img width="661" alt="Screenshot 2020-06-20 at 20 22 12" src="https://user-images.githubusercontent.com/7466983/85209951-08786280-b334-11ea-83d9-2c049a51c33b.png">

As you can see, panels with shorter dimensions are currently mapped to the top left corner. Is it worth trying to align these to centre? The code may also need some cleaning up...
