### PR TITLE
Various fixes

### DIFF
--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -489,21 +489,21 @@ void run ()
 
       switch (event) {
         case VT::Up:
-        case VT::MouseWheelUp:
           switch(arrow_mode) {
             case ARROW_SLICEVOL:  ++focus[slice_axis];   break;
             case ARROW_CROSSHAIR: ++focus[y_axis]; break;
             case ARROW_COLOUR:    colourmap.update_scaling (0, -1); break;
             default: break;
           } break;
+        case VT::MouseWheelUp: ++focus[slice_axis]; break;
         case VT::Down:
-        case VT::MouseWheelDown:
           switch(arrow_mode) {
             case ARROW_SLICEVOL:  --focus[slice_axis];   break;
             case ARROW_CROSSHAIR: --focus[y_axis]; break;
             case ARROW_COLOUR:    colourmap.update_scaling (0, 1); break;
             default: break;
           } break;
+        case VT::MouseWheelDown: --focus[slice_axis]; break;
         case VT::Left:
           switch(arrow_mode) {
             case ARROW_SLICEVOL:  if (image.ndim() > 3) {--image.index(3);

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -416,7 +416,11 @@ void run ()
     throw Exception("slice " + str(focus[slice_axis]) + " exceeds image size (" + str(image.size(slice_axis)) + ") in axis " + str(slice_axis));
 
   colourmap_ID = get_option_value ("colourmap", colourmap_ID);
-  levels = get_option_value ("levels", levels);
+
+  //CONF option: MRPeekColourmapLevels
+  //CONF default: 32
+  //CONF set the default number of colourmap levels to use within mrpeek
+  levels = get_option_value ("levels", File::Config::get_int ("MRPeekColourmapLevels", levels));
 
   Sixel::ColourMap colourmap (ColourMap::maps[colourmap_ID], levels);
 
@@ -444,16 +448,16 @@ void run ()
   }
 
   //CONF option: MRPeekOrthoView
-  orthoview = get_option_value ("orthoview", MR::File::Config::get_bool ("MRPeekOrthoView", orthoview));
+  orthoview = get_option_value ("orthoview", File::Config::get_bool ("MRPeekOrthoView", orthoview));
 
   //CONF option: MRPeekScaleImage
-  scale_image = get_option_value ("scale_image", MR::File::Config::get_float ("MRPeekScaleImage", scale_image));
+  scale_image = get_option_value ("scale_image", File::Config::get_float ("MRPeekScaleImage", scale_image));
   if (scale_image <= 0)
     throw Exception ("scale_image value needs to be positive");
   INFO("scale_image: " + str(scale_image));
 
   //CONF option: MRPeekInteractive
-  if (!interactive or !get_option_value ("interactive", MR::File::Config::get_bool ("MRPeekInteractive", true))) {
+  if (!interactive or !get_option_value ("interactive", File::Config::get_bool ("MRPeekInteractive", true))) {
     interactive = false;
     display (image, colourmap);
     std::cout << "\n";

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -265,6 +265,7 @@ void display (Image<value_type>& image, Sixel::ColourMap& colourmap)
       encoder.draw_boundingbox (interactive && slice_axis == backup_slice_axis);
     }
     slice_axis = backup_slice_axis;
+    set_axes();
 
     // encode buffer and print out:
     encoder.write();

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -94,7 +94,7 @@ void usage ()
   +   Argument ("y").type_integer()
 
   + Option ("levels",
-            "number of intensity levels in the colourmap. Default is 64.")
+            "number of intensity levels in the colourmap. Default is 32.")
   +   Argument ("number").type_integer (2)
 
   + Option ("scale_image",
@@ -139,7 +139,7 @@ value_type percentile (Container& data, default_type percentile)
 // Global variables to hold slide dislay parameters:
 // These will need to be moved into a struct/class eventually...
 int colourmap_ID = 0;
-int levels = 64;
+int levels = 32;
 int x_axis, y_axis, slice_axis = 2;
 value_type pmin = DEFAULT_PMIN, pmax = DEFAULT_PMAX, scale_image = 1.0;
 bool crosshair = true, colorbar = true, orthoview = true, interactive = true;

--- a/src/sixel.h
+++ b/src/sixel.h
@@ -120,8 +120,8 @@ namespace MR {
           const int h = 20, w = 90;
           if (x_dim < 2*w || y_dim < 2*h)
             return;
-          int y1 = y_dim-h-1, y0 = y1-h-1;
-          int x1 = x_dim-h-1, x0 = x1-w-1;
+          int y1 = y_dim-4, y0 = y1-h-1;
+          int x1 = x_dim-4, x0 = x1-w-1;
           for (int y = y0; y <= y1; y++) {
             for (int x = x0; x <= x1; x++) {
               int val = (x-x0) * colourmap.range() / w;

--- a/src/sixel.h
+++ b/src/sixel.h
@@ -117,14 +117,15 @@ namespace MR {
         }
 
         void draw_colourbar () {
-          const int h = 20, w = 90;
+          const int h = 90, w = 14;
           if (x_dim < 2*w || y_dim < 2*h)
             return;
           int y1 = y_dim-4, y0 = y1-h-1;
           int x1 = x_dim-4, x0 = x1-w-1;
+
           for (int y = y0; y <= y1; y++) {
+            int val = (h-(y-y0)) * colourmap.range() / h;
             for (int x = x0; x <= x1; x++) {
-              int val = (x-x0) * colourmap.range() / w;
               data[mapxy(x,y)] = (y==y0 || y==y1 || x==x0 || x==x1) ? colourmap.crosshairs() : val;
             }
           }


### PR DESCRIPTION
- moving the crosshairs in orthoview was not working as expected: whether using the left-click mouse or arrows, the cursor moved as if display was set to axial, regardless of which projection was active.
- make sure the mouse wheel only moves through slices. I don't think it makes sense to interpret it as a move focus or adjust contrast operation when in those modes.
- move the colourmap further into the corner of the image, away from the content. I found it obscured the image more than I'd have liked. Ideally, I'd actually make it vertical and move it to the left- or right-most edge of the display, without overlapping over any of the images displayed - but that'll be for another time...
- set the default number of colourmap levels to 32, down from 64. In my experience, I can barely tell the difference, and it does help reduce frame size. I'll post some data on that in a later post. 