### PR TITLE
add workflow to create macos binary

### DIFF
--- a/.github/workflows/package-linux.yaml
+++ b/.github/workflows/package-linux.yaml
@@ -66,5 +66,5 @@ jobs:
     - name: Upload package to GitHub Release
       uses: AButler/upload-release-assets@v2.0
       with:
-        files: 'bin/mrpeek'
+        files: 'mrpeek-macos.tar.gz'
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-linux.yaml
+++ b/.github/workflows/package-linux.yaml
@@ -27,8 +27,11 @@ jobs:
     - name: build
       run: ./mrtrix3/build -nowarnings -persistent -nopaginate || { cat build.log; false; }
 
+    - name: package
+      run: tar cvfz mrpeek-linux.tar.gz mrpeek
+
     - name: Upload package to GitHub Release
       uses: AButler/upload-release-assets@v2.0
       with:
-        files: 'bin/mrpeek'
+        files: 'mrpeek-linux.tar.gz'
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-linux.yaml
+++ b/.github/workflows/package-linux.yaml
@@ -41,6 +41,9 @@ jobs:
   package-macos:
     runs-on: macos-latest
     
+    env: 
+      MACOSX_DEPLOYMENT_TARGET: 10.13
+      
     steps:
     - uses: actions/checkout@v1
 
@@ -52,7 +55,7 @@ jobs:
       
     - name: configure MRtrix3 core
       working-directory: mrtrix3
-      run: LINKFLAGS="-static-libgcc -static-libstdc++" EIGEN_CFLAGS="-isystem $(pwd)/../eigen" TIFF_CFLAGS=none FFTW_CFLAGS=none PNG_CFLAGS=none ./configure -nogui -noshared || { cat configure.log; false; }
+      run: EIGEN_CFLAGS="-isystem $(pwd)/../eigen" TIFF_CFLAGS=none FFTW_CFLAGS=none PNG_CFLAGS=none ./configure -nogui -noshared || { cat configure.log; false; }
 
     - name: build
       run: ./mrtrix3/build -nowarnings -persistent -nopaginate || { cat build.log; false; }

--- a/.github/workflows/package-linux.yaml
+++ b/.github/workflows/package-linux.yaml
@@ -28,10 +28,40 @@ jobs:
       run: ./mrtrix3/build -nowarnings -persistent -nopaginate || { cat build.log; false; }
 
     - name: package
-      run: tar cvfz mrpeek-linux.tar.gz mrpeek
+      run: tar cvfz mrpeek-linux.tar.gz -C bin/ mrpeek
 
     - name: Upload package to GitHub Release
       uses: AButler/upload-release-assets@v2.0
       with:
         files: 'mrpeek-linux.tar.gz'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+
+
+  package-macos:
+    runs-on: macos-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: fetch Eigen3
+      run: git clone --single-branch --branch 3.3.7 https://gitlab.com/libeigen/eigen.git
+         
+    - name: fetch MRtrix3 core
+      run: git clone --single-branch --branch master https://github.com/MRtrix3/mrtrix3.git
+      
+    - name: configure MRtrix3 core
+      working-directory: mrtrix3
+      run: LINKFLAGS="-static-libgcc -static-libstdc++" EIGEN_CFLAGS="-isystem $(pwd)/../eigen" TIFF_CFLAGS=none FFTW_CFLAGS=none PNG_CFLAGS=none ./configure -nogui -noshared || { cat configure.log; false; }
+
+    - name: build
+      run: ./mrtrix3/build -nowarnings -persistent -nopaginate || { cat build.log; false; }
+
+    - name: package
+      run: tar cvfz mrpeek-macos.tar.gz -C bin/ mrpeek
+
+    - name: Upload package to GitHub Release
+      uses: AButler/upload-release-assets@v2.0
+      with:
+        files: 'bin/mrpeek'
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,31 +1,42 @@
-name: package-linux
+name: package
 
 on:
   release:
     types: [created]
 
 jobs:
-  package:
+  package-linux:
 
-    runs-on: ubuntu-16.04
-    
+    runs-on: ubuntu-latest
+
+    container:
+      image: ubuntu:trusty
+
     steps:
-    - uses: actions/checkout@v1
-
-    - name: install dependencies
+    - uses: actions/checkout@v2
+    - name: add ubuntu-toolchain PPA
       run: |
-         sudo apt-get update
-         sudo apt-get install clang-5.0 libeigen3-dev zlib1g-dev
-         
-    - name: fetch MRtrix3 core
+        apt-get install -y software-properties-common
+        add-apt-repository -y ppa:ubuntu-toolchain-r/test
+
+    - name: update and install dependencies
+      run: |
+        apt-get update
+        apt-get upgrade -y
+        apt-get install -y g++-9 git zlib1g-dev python
+
+    - name: fetch Eigen3
+      run: git clone --single-branch --branch 3.3.7 https://gitlab.com/libeigen/eigen.git
+
+    - name: fetch MRtrix core
       run: git clone --single-branch --branch master https://github.com/MRtrix3/mrtrix3.git
-      
+
     - name: configure MRtrix3 core
       working-directory: mrtrix3
-      run: LINKFLAGS="-static-libgcc -static-libstdc++" TIFF_CFLAGS=none FFTW_CFLAGS=none PNG_CFLAGS=none ./configure -nogui -noshared || { cat configure.log; false; }
+      run: CXX=g++-9 LINKFLAGS="-static-libgcc -static-libstdc++" EIGEN_CFLAGS="-isystem $(pwd)/../eigen" TIFF_CFLAGS=none FFTW_CFLAGS=none PNG_CFLAGS=none ./configure -nogui -noshared
 
     - name: build
-      run: ./mrtrix3/build -nowarnings -persistent -nopaginate || { cat build.log; false; }
+      run: ./mrtrix3/build
 
     - name: package
       run: tar cvfz mrpeek-linux.tar.gz -C bin/ mrpeek
@@ -33,26 +44,26 @@ jobs:
     - name: Upload package to GitHub Release
       uses: AButler/upload-release-assets@v2.0
       with:
-        files: 'mrpeek-linux.tar.gz'
+        files: 'bin/mrpeek'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
 
 
   package-macos:
     runs-on: macos-latest
-    
-    env: 
+
+    env:
       MACOSX_DEPLOYMENT_TARGET: 10.13
-      
+
     steps:
     - uses: actions/checkout@v1
 
     - name: fetch Eigen3
       run: git clone --single-branch --branch 3.3.7 https://gitlab.com/libeigen/eigen.git
-         
+
     - name: fetch MRtrix3 core
       run: git clone --single-branch --branch master https://github.com/MRtrix3/mrtrix3.git
-      
+
     - name: configure MRtrix3 core
       working-directory: mrtrix3
       run: EIGEN_CFLAGS="-isystem $(pwd)/../eigen" TIFF_CFLAGS=none FFTW_CFLAGS=none PNG_CFLAGS=none ./configure -nogui -noshared || { cat configure.log; false; }

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -44,7 +44,7 @@ jobs:
     - name: Upload package to GitHub Release
       uses: AButler/upload-release-assets@v2.0
       with:
-        files: 'bin/mrpeek'
+        files: 'mrpeek-linux.tar.gz'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
 


### PR DESCRIPTION
Both for smaller filesize, and to allow different filenames (will be useful when other platforms are added).