### PR TITLE
mrpeek: added no text mode, modified boolean cmd line options

### DIFF
--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -959,16 +959,18 @@ void run ()
   colorbar = show_text = !get_options ("notext").size();
   show_image = !get_options ("noimage").size();
 
-#ifndef MRTRIX_WINDOWS
-  //CONF option: MRPeekInteractive
-  if (!interactive or get_options("batch").size()) {
-#endif
+#ifdef MRTRIX_WINDOWS
+  interactive = false;
+  std::cout << display (image, colourmaps) << "\n";
+#else
+  interactive = isatty (STDOUT_FILENO);
+  if (get_options ("batch").size())
     interactive = false;
+
+  if (!interactive) {
     std::cout << display (image, colourmaps) << "\n";
     return;
-#ifndef MRTRIX_WINDOWS
   }
-
 
   try {
     // start loop

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -607,7 +607,7 @@ std::string display (ImageType& image, Sixel::ColourMaps& colourmaps)
 
   if (show_text) out += show_focus(image);
 
-  if (interactive and orthoview and show_text) {
+  if (interactive && orthoview && show_text) {
     out += " | active: ";
     switch (slice_axis) {
       case (0): out += std::string (TextUnderscore) + "s" + TextReset + "agittal"; break;
@@ -617,7 +617,7 @@ std::string display (ImageType& image, Sixel::ColourMaps& colourmaps)
     };
   }
 
-  if (interactive and show_text)
+  if (interactive && show_text)
     out += std::string(" | help: ") + TextUnderscore + "?" + TextReset;
   if (do_plot)
     out += plot (image, plot_axis);

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -941,6 +941,7 @@ void run ()
       throw Exception ("number of indices passed to -focus option exceeds image dimensions");
     for (unsigned int n = 0; n < p.size(); ++n) {
       if (std::isfinite (p[n])) {
+        p[n] = Math::round<default_type>(p[n]);
         if (p[n] < 0 || p[n] > image.size(n)-1)
           throw Exception ("position passed to -focus option is out of bounds for axis "+str(n));
         if (n < 3)

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -123,6 +123,10 @@ void usage ()
 
   + Option ("text",
             "optionally omit text output to show only the sixel image")
+  +   Argument ("yesno").type_bool()
+
+  + Option ("image",
+            "render the main image. Default: true")
   +   Argument ("yesno").type_bool();
 }
 
@@ -430,7 +434,7 @@ std::string plot (ImageType& image, int plot_axis)
     assert(y < y_dim);
     assert(y >= 0);
 
-    if ((plot_axis < 3 && index == focus[plot_axis]) || (plot_axis > 2 && index == current_index)) {
+    if (crosshair && ((plot_axis < 3 && index == focus[plot_axis]) || (plot_axis > 2 && index == current_index))) {
       // focus position: draw line
       for (int r = 0; r < y_offset; ++r)
         canvas (x_offset+x, r) = CROSSHAIR_COLOUR;
@@ -953,6 +957,7 @@ void run ()
   zoom /= std::min (std::min (image.spacing(0), image.spacing(1)), image.spacing(2));
 
   colorbar = show_text = get_option_value ("text", true);
+  show_image = get_option_value ("image", true);
 
 #ifndef MRTRIX_WINDOWS
   //CONF option: MRPeekInteractive

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -105,10 +105,10 @@ void usage ()
 
   + Option ("focus",
             "set focus (crosshairs) at specified position, as a comma-separated "
-            "list of values. Use empty entries to leave as default (e.g. '-focus ,,100' "
+            "list of integer-valued voxel indices. Use empty entries to leave as default (e.g. '-focus ,,100' "
             "to place the focus on slice 100 along the z-axis, or '-focus ,,,4' to "
             "select volume 4).")
-  +   Argument ("pos").type_sequence_float()
+  +   Argument ("pos").type_sequence_int()
 
   + Option ("levels",
             "number of intensity levels in the colourmap. Default is 32.")
@@ -936,7 +936,7 @@ void run ()
 
   opt = get_options ("focus");
   if (opt.size()) {
-    vector<default_type> p = opt[0][0];
+    vector<int> p = opt[0][0];
     if (p.size() > image.ndim())
       throw Exception ("number of indices passed to -focus option exceeds image dimensions");
     for (unsigned int n = 0; n < p.size(); ++n) {

--- a/cmd/mrpeek.cpp
+++ b/cmd/mrpeek.cpp
@@ -105,10 +105,10 @@ void usage ()
 
   + Option ("focus",
             "set focus (crosshairs) at specified position, as a comma-separated "
-            "list of integer-valued voxel indices. Use empty entries to leave as default (e.g. '-focus ,,100' "
+            "list of values. Use empty entries to leave as default (e.g. '-focus ,,100' "
             "to place the focus on slice 100 along the z-axis, or '-focus ,,,4' to "
             "select volume 4).")
-  +   Argument ("pos").type_sequence_int()
+  +   Argument ("pos").type_sequence_float()
 
   + Option ("levels",
             "number of intensity levels in the colourmap. Default is 32.")
@@ -936,7 +936,7 @@ void run ()
 
   opt = get_options ("focus");
   if (opt.size()) {
-    vector<int> p = opt[0][0];
+    vector<default_type> p = opt[0][0];
     if (p.size() > image.ndim())
       throw Exception ("number of indices passed to -focus option exceeds image dimensions");
     for (unsigned int n = 0; n < p.size(); ++n) {


### PR DESCRIPTION
Added an option to remove text output in interactive or non-interactive mode. In non-interactive mode, this allows writing a sixel image to file via 

```
mrpeek im.mif -text no -inter no > im.sixel
mrpeek im.mif -text no -inter no -image no -cross -1 -1 -plot 0 > plot.sixel
``` 

which can then be displayed via `cat` on supported terminals or converted to png using [sixel2png](img2sixel).