### PR TITLE
Use correct sixel start sequence

### DIFF
--- a/src/sixel.h
+++ b/src/sixel.h
@@ -17,7 +17,7 @@ namespace MR {
     constexpr float BrightnessIncrement = 0.01f;
     constexpr float ContrastIncrement = 0.03f;
 
-    constexpr const char* SixelStart = "\033Pq$";
+    constexpr const char* SixelStart = "\033P9;1q$";
     constexpr const char* SixelStop = "\033\\";
 
     void init();


### PR DESCRIPTION
This fixes the aspect ratio on Windows Terminal Preview, and sets the background to transparent, which avoids some visual artefacts on Windows Terminal. Technically, I'm pretty sure the implementation on Windows Terminal is correct, and these changes don't affect the appearance on other terminals. 